### PR TITLE
Add simple FastAPI endpoint

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+async def read_root():
+    return {"message": "HelloWorld"}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- implement a basic FastAPI server that returns HelloWorld

## Testing
- `pytest -q`
- `python api.py` (started and stopped briefly to verify the server starts)

------
https://chatgpt.com/codex/tasks/task_e_683f5f145b148324bd44f1d1e2448a41